### PR TITLE
Develop

### DIFF
--- a/src/Base/Types.ts
+++ b/src/Base/Types.ts
@@ -3,6 +3,7 @@ import GomlInterfaceImpl from "../Interface/GomlInterfaceImpl";
 import GomlNode from "../Node/GomlNode";
 import GrimoireInterfaceImpl from "../Interface/GrimoireInterfaceImpl";
 import NodeInterface from "../Interface/NodeInterface";
+import IAttributeDeclaration from "../Node/IAttributeDeclaration";
 
 export type Name = string | NSIdentity;
 export type GomlInterface = GomlInterfaceImpl & IGomlInterface;
@@ -18,5 +19,10 @@ export type GrimoireInterface = IGrimoireInterface & GrimoireInterfaceImpl;
 export type Nullable<T> = T | null;
 export type Undef<T> = Nullable<T> | undefined;
 export type Ctor<T> = (new () => T);
+export type ComponentRegistering<T> = T & {
+  attributes: { [key: string]: IAttributeDeclaration };
+  componentName?: Name;
+  [key: string]: any;
+};
 
 export default null;

--- a/src/Components/GrimoireComponent.ts
+++ b/src/Components/GrimoireComponent.ts
@@ -1,7 +1,8 @@
 import IAttributeDeclaration from "../Node/IAttributeDeclaration";
 import Component from "../Node/Component";
 
-class GrimoireComponent extends Component {
+export default class GrimoireComponent extends Component {
+  public static componentName = "GrimoireComponent";
   public static attributes: { [key: string]: IAttributeDeclaration } = {
     id: {
       converter: "String",
@@ -35,5 +36,3 @@ class GrimoireComponent extends Component {
     node["_isActive"] = node.parent ? node.parent.isActive && node.enabled : node.enabled;
   }
 }
-
-export default GrimoireComponent;


### PR DESCRIPTION
# fix component inheritance bug
- `ComponentDecralation.resolvedDependency` rename to `isDependenyResolved`
- add overload to `gr.registerComponent`  
  - `name` can be omitted. use `name` property of component-object/constructor instead of.
- change specification of registerComponent.

# new specification of `gr.registerComponent`
- throw error immediately if given constructor is not inherits Component.
- if register by `object`
  -  generate new constructor that has given object as prototype.
  - rewrite __proto__ of given object  to `Component` or given base consutructor.
- if register by constructor
  - if base-constructor is not given, search `attributes` recursively and merge.
  - if base-constructor is given, generate new constructor inherits base and given constructor, and merge `attributes`.  Use object that traced back prototype-chain to the `Component` and clone it , and connect the prototype of the base constructor at the end as prototype of the generated constructor..