### PR TITLE
Feat/parametric object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ test-lib
 test-lib-es5
 src/metaInfo.ts
 package-lock.json
+.vscode

--- a/src/Core/Component.ts
+++ b/src/Core/Component.ts
@@ -9,6 +9,9 @@ import ComponentDeclaration from "./ComponentDeclaration";
 import GomlNode from "./GomlNode";
 import Identity from "./Identity";
 import IdentityMap from "./IdentityMap";
+import IParametricObject from "../Interface/IParametricObject";
+import Namespace from "./Namespace";
+import ParametricObjectContext from "./ParametricObjectContext";
 
 /**
  * Base class for any components
@@ -61,6 +64,7 @@ export default class Component extends IDObject {
   private _handlers: ((component: Component) => void)[] = [];
   private _additionalAttributesNames: Identity[] = [];
   private _initializedInfo: Nullable<ITreeInitializedInfo> = null;
+  private _parametricContextMap: { [key: string]: ParametricObjectContext } = {};
 
   /**
    * whether component enabled.
@@ -255,5 +259,62 @@ export default class Component extends IDObject {
    */
   protected __setCompanionWithSelfNS(name: string, value: any) {
     this.companion.set(this.name.ns.for(name), value);
+  }
+
+  /**
+   * 
+   * @param obj Parametric object that is managed in this component
+   * @param baseName namespace base of this parametric object. Used for determining fqn.
+   */
+  protected __attachParametricObject(obj: IParametricObject, baseName: string): ParametricObjectContext {
+    const decls = obj.getAttributeDeclarations();
+    if (obj.owner) {
+      throw new Error(`Parametric object is not attachable for multiple component.`);
+    }
+    if (this._parametricContextMap[baseName]) {
+      throw new Error(`Parametric object for ${baseName} is already registered`);
+    }
+    obj.owner = this;
+    const ns = Namespace.define(baseName);
+    const nsMap: { [key: string]: string | ParametricObjectContext } = {};
+    for (let key in decls) {
+      const decl = decls[key];
+      if (this._isParametricObject(decl)) {
+        const poc = this.__attachParametricObject(decl, `${baseName}.${key}`);
+        nsMap[key] = poc;
+      } else {
+        const identity = ns.for(key);
+        this.__addAttribute(identity.fqn, decl);
+        nsMap[key] = identity.fqn;
+      }
+    }
+    const poc = new ParametricObjectContext(obj, this, baseName, nsMap);
+    this._parametricContextMap[baseName] = poc;
+    obj.onAttachComponent(this, poc);
+    return poc;
+  }
+
+  /**
+   * Remove specified parametric object if exists
+   * @param baseName parametric object base name
+   */
+  protected __detachParametricObject(baseName: string): void {
+    const poc = this._parametricContextMap[baseName];
+    if (!poc) {
+      return;
+    }
+    for (let name in poc.nameToKey) {
+      const key = poc.nameToKey[name];
+      if (typeof key === "string") {
+        this.__removeAttributes(key);
+      } else {
+        this.__detachParametricObject(poc.baseName);
+      }
+    }
+    poc.target.onDetachComponent(this, poc);
+  }
+
+  private _isParametricObject(obj: any): obj is IParametricObject {
+    return obj && typeof obj.getAttributeDeclarations === "function";
   }
 }

--- a/src/Core/ParametricObjectContext.ts
+++ b/src/Core/ParametricObjectContext.ts
@@ -1,0 +1,40 @@
+import IParametricObject from "../Interface/IParametricObject";
+import Component from "./Component";
+import Attribute from "./Attribute";
+import { Nullable } from "../Tool/Types";
+
+export default class ParametricObjectContext {
+    constructor(public target: IParametricObject, public component: Component, public baseName: string, public nameToKey: { [key: string]: string | ParametricObjectContext }) {
+
+    }
+
+    public getAttributeRaw<T = any>(name: string): Nullable<Attribute<T>> {
+        return this.component.getAttributeRaw<T>(this._ensureFQN(name));
+    }
+
+    public getAttribute<T = any>(name: string): T {
+        return this.component.getAttribute(this._ensureFQN(name));
+    }
+
+    public setAttribute<T = any>(name: string, val: T): void {
+        this.component.setAttribute(this._ensureFQN(name), val);
+    }
+
+    public bindAttributes(target: any = this.target): void {
+        for (let name in this.nameToKey) {
+            const key = this.nameToKey[name];
+            if (typeof key === "string") {
+                this.component.getAttributeRaw(key)!.bindTo(name, target);
+            }
+        }
+    }
+
+    private _ensureFQN(name: string): string {
+        const fqnOrCop = this.nameToKey[name];
+        if (typeof fqnOrCop === "string") {
+            return fqnOrCop;
+        } else {
+            throw new Error(`${name} is not valid for this parametric object`);
+        }
+    }
+}

--- a/src/Interface/IParametricObject.ts
+++ b/src/Interface/IParametricObject.ts
@@ -1,0 +1,10 @@
+import Component from "../Core/Component";
+import IAttributeDeclaration from "./IAttributeDeclaration";
+import ParametricObjectContext from "../Core/ParametricObjectContext";
+
+export default interface IParametricObject {
+    owner?: Component;
+    getAttributeDeclarations(): { [key: string]: IAttributeDeclaration | IParametricObject };
+    onAttachComponent(component: Component, ctx: ParametricObjectContext): void;
+    onDetachComponent(lastComponent: Component, ctx: ParametricObjectContext): void;
+}


### PR DESCRIPTION
GeometryやMaterialなど、コンポーネントではないが、コンポーネントに動的な値を持つ集合として扱わせたいもの。


- ownerはattachされたコンポーネント。attachできるコンポーネントは一つだけ
- attachParametricObjectでは、すでにownerがあった場合例外
- getAttributeDeclarationsでは、そのParametricObjectが持つ属性への定義か、こ要素となるIParametricObjectへの参照が代入される
- attachParametricObjectではbaseNameを名前空間に考慮して入れる。${LIB_NAMESPACE}.${COMPONENT}.${BASENAME}.${ATTR_NAME} 

    interface IParametricObject{
        owner?:Component;
        getAttributeDeclarations():{[key:string]:IAttributeDeclaration|IParametricObject};
        onAttachComponent(component:Component,ctx:ParametricObjectContext):void;
        onDetachComponent(lastComponent:Component,ctx:ParametricObjectContext):void;
    }


- Component#__attachParametricObject(obj:IParametricObject,baseName:string)
- Component#__detachParametricObject(baseName:string);


- ParametricObjectContext#bindTo()
- ParametricObjectContext#watch()
- ParametricObjectContext#getAttributeRaw