### PR TITLE
[new feat] implemnent gr#import

### DIFF
--- a/src/Core/GrimoireInterfaceImpl.ts
+++ b/src/Core/GrimoireInterfaceImpl.ts
@@ -141,6 +141,27 @@ export default class GrimoireInterfaceImpl extends EEObject {
     return GomlLoader.callInitializedAlready;
   }
 
+  public import(path: string): any {
+    const pathes = path.split("/");
+    Utility.assert(pathes.length > 2 && pathes[1] === "ref", `invalid import path: ${path}`);
+    const pluginName = pathes[0];
+    const importPath = pathes.slice(2);
+    for (const key in this.lib) {
+      let target = this.lib[key];
+      if (target.__NAME__ === pluginName) {
+        for (let i = 0; i < importPath.length; i++) {
+          if (target[importPath[i]]) {
+            target = target[importPath[i]];
+          } else {
+            throw new Error(`import path ${path} is not found in ${pluginName}`);
+          }
+        }
+        return target;
+      }
+    }
+    throw new Error(`plugin ${pluginName} is not registered.`);
+  }
+
   /**
    * start observation goml mutation.
    */

--- a/src/Core/GrimoireInterfaceImpl.ts
+++ b/src/Core/GrimoireInterfaceImpl.ts
@@ -146,6 +146,17 @@ export default class GrimoireInterfaceImpl extends EEObject {
     Utility.assert(pathes.length > 2 && pathes[1] === "ref", `invalid import path: ${path}`);
     const pluginName = pathes[0];
     const importPath = pathes.slice(2);
+    if (pluginName === "grimoirejs") {
+      let target = this as any;
+      for (let i = 0; i < importPath.length; i++) {
+        if (target[importPath[i]]) {
+          target = target[importPath[i]];
+        } else {
+          throw new Error(`import path ${path} is not found in ${pluginName}`);
+        }
+      }
+      return target;
+    }
     for (const key in this.lib) {
       let target = this.lib[key];
       if (target.__NAME__ === pluginName) {

--- a/test/Core/GrimoireInterfaceTest.ts
+++ b/test/Core/GrimoireInterfaceTest.ts
@@ -364,3 +364,48 @@ test("register and resolvePlugins works preperly", async() => {
   await GrimoireInterface.resolvePlugins();
   assert.callOrder(spy1, spy2);
 });
+
+test("import works preperly", async t => {
+  GrimoireInterface.lib.hoge = {
+    __NAME__: "grimoirejs-hoge",
+    __VERSION__: "1.2.3",
+  };
+  const component = {
+    ComponentA: 1,
+    ComponentB: 2,
+    ComponentC: 3,
+  };
+  const converter = {
+    ConverterA: 4,
+    ConverterB: 5,
+    ConverterC: 6,
+  };
+  GrimoireInterface.lib.hoge.Component = component;
+  GrimoireInterface.lib.hoge.Converter = converter;
+
+  t.truthy(GrimoireInterface.import("grimoirejs-hoge/ref/Component/ComponentA") === 1);
+  let err = t.throws(() => {
+    GrimoireInterface.import("invalidpath");
+  });
+  t.truthy(err.message.includes("invalid"));
+
+  err = t.throws(() => {
+    GrimoireInterface.import("notfound/ref/Component/HogeComponent");
+  });
+  t.truthy(err.message.includes("is not registered."));
+
+  err = t.throws(() => {
+    GrimoireInterface.import("grimoirejs-hoge/ref/notfound/ComponentA");
+  });
+  t.truthy(err.message.includes("not found"));
+
+  err = t.throws(() => {
+    GrimoireInterface.import("grimoirejs-hoge/ref/Component/Component");
+  });
+  t.truthy(err.message.includes("not found"));
+
+  err = t.throws(() => {
+    GrimoireInterface.import("grimoirejs-hoge/ref/Component/ComponentA/Component");
+  });
+  t.truthy(err.message.includes("not found"));
+});

--- a/test/Core/GrimoireInterfaceTest.ts
+++ b/test/Core/GrimoireInterfaceTest.ts
@@ -382,8 +382,10 @@ test("import works preperly", async t => {
   };
   GrimoireInterface.lib.hoge.Component = component;
   GrimoireInterface.lib.hoge.Converter = converter;
+  (GrimoireInterface as any).Core = { GomlNode: 7 };
 
   t.truthy(GrimoireInterface.import("grimoirejs-hoge/ref/Component/ComponentA") === 1);
+  t.truthy(GrimoireInterface.import("grimoirejs/ref/Core/GomlNode") === 7);
   let err = t.throws(() => {
     GrimoireInterface.import("invalidpath");
   });


### PR DESCRIPTION
`gr#import` is an alternative to `gr.lib`.

You can reference modules in the same path as typescript import.

```
let MaterialContainer =  gr.import("grimoirejs-fundamental/ref/Components/MaterialContainer");
let GomlNode = gr.import("grimoirejs/ref/Core/Node");
```
if plugin is not found, an error will occur.
if plugin is found but module is not found, a different error will occur.

