### PR TITLE
[new feat] Plugin assertion

### DIFF
--- a/src/Core/GrimoireInterfaceImpl.ts
+++ b/src/Core/GrimoireInterfaceImpl.ts
@@ -176,6 +176,17 @@ export default class GrimoireInterfaceImpl extends EEObject {
   }
 
   /**
+   * assert that specified plugin is registerd.
+   * if not, throw an error.
+   * @param pluginName namespace of plugin, e.g. 'fundamental','math'.
+   * @param message error message used when plugin is not registerd.
+   */
+  public assertPlugin(pluginName: string, message?: string) {
+    message = message || `required plugin ${pluginName} is not registerd.`;
+    Utility.assert(!!this.lib[pluginName], message);
+  }
+
+  /**
    * initialize GrimoireInterface.
    * register primitive coverters/nodes.
    * if you want reset state. use GrimoireInterface.clear() instead of.

--- a/src/Core/GrimoireInterfaceImpl.ts
+++ b/src/Core/GrimoireInterfaceImpl.ts
@@ -182,7 +182,7 @@ export default class GrimoireInterfaceImpl extends EEObject {
    * @param message error message used when plugin is not registerd.
    */
   public assertPlugin(pluginName: string, message?: string) {
-    message = message || `required plugin ${pluginName} is not registerd.`;
+    message = message || `required plugin '${pluginName}' is not registered.`;
     Utility.assert(!!this.lib[pluginName], message);
   }
 

--- a/test/Core/GrimoireInterfaceTest.ts
+++ b/test/Core/GrimoireInterfaceTest.ts
@@ -364,3 +364,22 @@ test("register and resolvePlugins works preperly", async() => {
   await GrimoireInterface.resolvePlugins();
   assert.callOrder(spy1, spy2);
 });
+
+test("assert works preperly", t => {
+  GrimoireInterface.lib.plugin = {
+    __NAME__: "grimoirejs-plugin",
+    __VERSION__: "1.2.3",
+  };
+  t.notThrows(() => {
+    GrimoireInterface.assertPlugin("plugin");
+  });
+  t.throws(() => {
+    GrimoireInterface.assertPlugin("notfound");
+  });
+
+  const errorMessage = "this is an error message";
+  const err = t.throws(() => {
+    GrimoireInterface.assertPlugin("notfound", errorMessage);
+  });
+  t.truthy(err.message === errorMessage);
+});


### PR DESCRIPTION
dynamic assertion that a plugin is registerd.

```
gr.assertPlugin("fundamental");
gr.assertPlugin("notfound"); // Error: required plugin 'notfound' is not registered.
gr.assertPlugin("notfound", "You can change the error message"); // Error: You can change the error message
```